### PR TITLE
Bug 32299

### DIFF
--- a/koha-tmpl/intranet-tmpl/prog/en/modules/cataloguing/z3950_search.tt
+++ b/koha-tmpl/intranet-tmpl/prog/en/modules/cataloguing/z3950_search.tt
@@ -118,6 +118,7 @@
             <div class="row">
                 <div class="col-xs-12">
                     <h1>Results</h1>
+                <div class="page-section">
                     <p>
                         You searched for:
                         [% IF ( title ) %]<em>Title: </em><span class="term">[% title | html %]</span> [% END %]
@@ -249,6 +250,7 @@
                     [% ELSE %]
                         <div class="dialog message">Nothing found.</div>
                     [% END  # /IF breeding_loop %]
+                    </div> <!-- /.page-section -->
 
                     <form method="get" action="/cgi-bin/koha/cataloguing/z3950_search.pl">
                         <p>


### PR DESCRIPTION
Added page-section to Z39.50 results table.

Testplan
Step 1: Navigate to Cataloguing module and click 'New from Z39.50/SRU' to start a search
Step 2: Carry out a search
Step 3: Confirm that the white background to the table of results is missing
Step 4: Apply patch
Step 6: repeat search
Step 7: Confirm that the white background is now showing.